### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/Highload Architect/docker-compose.yaml
+++ b/Highload Architect/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   pg-0:
-    image: bitnami/postgresql-repmgr:14
+    image: soldevelo/postgresql-repmgr:14
     ports:
       - "5434:5432"
     volumes:
@@ -17,7 +17,7 @@ services:
       - REPMGR_NODE_NETWORK_NAME=pg-0
 
   pg-1:
-    image: bitnami/postgresql-repmgr:14
+    image: soldevelo/postgresql-repmgr:14
     ports:
       - "5433:5432"
     volumes:
@@ -34,7 +34,7 @@ services:
       - REPMGR_NODE_NETWORK_NAME=pg-1
 
   pgpool:
-    image: bitnami/pgpool:4
+    image: soldevelo/pgpool:4.6
     ports:
       - "5432:5432"
     environment:

--- a/clickhouse/final_project/docker-compose.yaml
+++ b/clickhouse/final_project/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
       - final_project_default
 
   kafka:
-    image: docker.io/bitnami/kafka:4.0
+    image: docker.io/soldevelo/kafka:4.0
     ports:
       - "9092:9092"
     environment:


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/postgresql-repmgr:14` → [`soldevelo/postgresql-repmgr:14`](https://hub.docker.com/r/soldevelo/postgresql-repmgr)
- `bitnami/pgpool:4` → [`soldevelo/pgpool:4.6`](https://hub.docker.com/r/soldevelo/pgpool)
- `bitnami/kafka:4.0` → [`soldevelo/kafka:4.0`](https://hub.docker.com/r/soldevelo/kafka)